### PR TITLE
Fix NullPointerException in onActivityResult

### DIFF
--- a/android/src/main/java/dev/amirzr/flutter_v2ray_client/FlutterV2rayPlugin.java
+++ b/android/src/main/java/dev/amirzr/flutter_v2ray_client/FlutterV2rayPlugin.java
@@ -243,12 +243,14 @@ public class FlutterV2rayPlugin implements FlutterPlugin, ActivityAware, PluginR
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         if (requestCode == REQUEST_CODE_VPN_PERMISSION) {
-            if (resultCode == Activity.RESULT_OK) {
-                pendingResult.success(true);
-            } else {
-                pendingResult.success(false);
+            if (pendingResult != null) {
+                if (resultCode == Activity.RESULT_OK) {
+                    pendingResult.success(true);
+                } else {
+                    pendingResult.success(false);
+                }
+                pendingResult = null;
             }
-            pendingResult = null;
         }
         return true;
     }


### PR DESCRIPTION
- Add null check for pendingResult before calling success() method
- Prevents crash when onActivityResult is called multiple times or at unexpected times
- Maintains existing functionality while adding defensive programming
- Fixes issue where app crashes with 'Attempt to invoke interface method on a null object reference'

Resolves runtime exception in FlutterV2rayPlugin.onActivityResult at line 247